### PR TITLE
Add alternative for obtaining tabIndex for SVGs

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(el) {
   var candidate, candidateIndex;
   for (var i = 0, l = candidates.length; i < l; i++) {
     candidate = candidates[i];
-    candidateIndex = candidate.tabIndex;
+    candidateIndex = candidate.tabIndex || candidate.getAttribute('tabindex');
 
     if (
       candidateIndex < 0

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(el) {
   var candidate, candidateIndex;
   for (var i = 0, l = candidates.length; i < l; i++) {
     candidate = candidates[i];
-    candidateIndex = candidate.tabIndex || candidate.getAttribute('tabindex');
+    candidateIndex = parseInt(candidate.getAttribute('tabindex'), 10) || candidate.tabIndex;
 
     if (
       candidateIndex < 0


### PR DESCRIPTION
MS Edge and IE 11 have issues with SVGs whereby they make them tabbable even if their containing element has a `tabindex` of `-1 `or isn't even tabbable at all.

Adding `focusable="false"` and `tabindex="-1"` usually solves this, but `tabbable` is incorrectly adding them to its list of `tabbables`.

Calling `candidate.tabIndex` on an SVG returns `undefined`, but using `getAttribute('tabindex')`works fine.

This PR provides this as a fallback.