### PR TITLE
Use original dom position index to stabilize sort func

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = function(el) {
       basicTabbables.push(candidate);
     } else {
       orderedTabbables.push({
+        index: i,
         tabIndex: candidateIndex,
         node: candidate,
       });
@@ -43,7 +44,7 @@ module.exports = function(el) {
 
   var tabbableNodes = orderedTabbables
     .sort(function(a, b) {
-      return a.tabIndex - b.tabIndex;
+      return a.tabIndex === b.tabIndex ? a.index - b.index : a.tabIndex - b.tabIndex;
     })
     .map(function(a) {
       return a.node

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -93,7 +93,20 @@ describe('tabbable', function() {
   });
 
   it('non-linear', function() {
+    var originalSort = Array.prototype.sort;
+
+    // This sort piggy-backs on the default Array.prototype.sort, but always
+    // orders elements that were compared to be equal in reverse order of their
+    // index in the original array. We do this to simulate browsers who do not
+    // use a stable sort algorithm in their implementation.
+    Array.prototype.sort = function(compareFunction) {
+      return originalSort.call(this, function(a, b) {
+        var comparison = compareFunction ? compareFunction(a, b) : a - b;
+        return comparison || this.indexOf(b) - this.indexOf(a);
+      })
+    };
     var actual = fixture('non-linear').getTabbableIds();
+    Array.prototype.sort = originalSort;
     var expected = [
       // 1
       'input-1',


### PR DESCRIPTION
On some browsers (Chrome specifically) Array.prototype.sort is not stable. This causes the order of like-tabindexed elements to be unexpected in some cases.

By comparing the array index of elements from the querySelectorAll, we can tie-break elements with the same tabindex.