### PR TITLE
Feature/add iframe support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.8
 
-- Allows operation against elements that reside within iframes, by inspecting the element to determin its correct parent `document` (rather than relying on the global `document` object).
+- Allows operation against elements that reside within iframes, by inspecting the element to determine its correct parent `document` (rather than relying on the global `document` object).
 
 ## 1.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.8
+
+- Allows operation against elements that reside within iframes, by inspecting the element to determin its correct parent `document` (rather than relying on the global `document` object).
+
 ## 1.0.7
 
 - Ensure stable sort of `tabindex`ed elements even in browsers that have an unstable `Array.prototype.sort`.

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 module.exports = function(el) {
+  var elementDocument = el.ownerDocument;
   var basicTabbables = [];
   var orderedTabbables = [];
 
   // A node is "available" if
   // - it's computed style
-  var isUnavailable = createIsUnavailable();
+  var isUnavailable = createIsUnavailable(elementDocument);
 
   var candidateSelectors = [
     'input',
@@ -26,7 +27,7 @@ module.exports = function(el) {
       candidateIndex < 0
       || (candidate.tagName === 'INPUT' && candidate.type === 'hidden')
       || candidate.disabled
-      || isUnavailable(candidate)
+      || isUnavailable(candidate, elementDocument)
     ) {
       continue;
     }
@@ -54,7 +55,7 @@ module.exports = function(el) {
   return tabbableNodes;
 }
 
-function createIsUnavailable() {
+function createIsUnavailable(elementDocument) {
   // Node cache must be refreshed on every check, in case
   // the content of the element has changed
   var isOffCache = [];
@@ -65,14 +66,14 @@ function createIsUnavailable() {
   // "off" state, so we need to recursively check parents.
 
   function isOff(node, nodeComputedStyle) {
-    if (node === document.documentElement) return false;
+    if (node === elementDocument.documentElement) return false;
 
     // Find the cached node (Array.prototype.find not available in IE9)
     for (var i = 0, length = isOffCache.length; i < length; i++) {
       if (isOffCache[i][0] === node) return isOffCache[i][1];
     }
 
-    nodeComputedStyle = nodeComputedStyle || window.getComputedStyle(node);
+    nodeComputedStyle = nodeComputedStyle || elementDocument.defaultView.getComputedStyle(node);
 
     var result = false;
 
@@ -87,10 +88,10 @@ function createIsUnavailable() {
     return result;
   }
 
-  return function isUnavailable(node) {
-    if (node === document.documentElement) return false;
+  return function isUnavailable(node, elementDocument) {
+    if (node === elementDocument.documentElement) return false;
 
-    var computedStyle = window.getComputedStyle(node);
+    var computedStyle = elementDocument.defaultView.getComputedStyle(node);
 
     if (isOff(node, computedStyle)) return true;
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = function(el) {
       basicTabbables.push(candidate);
     } else {
       orderedTabbables.push({
+        index: i,
         tabIndex: candidateIndex,
         node: candidate,
       });
@@ -44,7 +45,7 @@ module.exports = function(el) {
 
   var tabbableNodes = orderedTabbables
     .sort(function(a, b) {
-      return a.tabIndex - b.tabIndex;
+      return a.tabIndex === b.tabIndex ? a.index - b.index : a.tabIndex - b.tabIndex;
     })
     .map(function(a) {
       return a.node

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function createIsUnavailable(elementDocument) {
     return result;
   }
 
-  return function isUnavailable(node, elementDocument) {
+  return function isUnavailable(node) {
     if (node === elementDocument.documentElement) return false;
 
     var computedStyle = elementDocument.defaultView.getComputedStyle(node);

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -13,7 +13,7 @@ var fixtures = {
 
 var fixtureRoots = [];
 
-function _createRootNode(doc, fixtureName) {
+function createRootNode(doc, fixtureName) {
   var html = fixtures[fixtureName];
   var root = doc.createElement('div');
   root.innerHTML = html;
@@ -21,17 +21,17 @@ function _createRootNode(doc, fixtureName) {
   return root;
 }
 
-function _getTabbableIds(node) {
+function getTabbableIds(node) {
   return tabbable(node).map(function(el) {
     return el.getAttribute('id');
   });
 }
 
 function fixture(fixtureName) {
-  var root = _createRootNode(document, fixtureName);
+  var root = createRootNode(document, fixtureName);
   fixtureRoots.push(root);
   return {
-    getTabbableIds: _getTabbableIds.bind(null, root),
+    getTabbableIds: getTabbableIds.bind(null, root),
     getDocument: function() { return document; },
   };
 }
@@ -41,7 +41,7 @@ function fixtureWithIframe(fixtureName) {
   document.body.appendChild(iframe);
   fixtureRoots.push(iframe);
   return {
-    getTabbableIds: _getTabbableIds.bind(null, _createRootNode(iframe.contentDocument, fixtureName)),
+    getTabbableIds: getTabbableIds.bind(null, createRootNode(iframe.contentDocument, fixtureName)),
     getDocument: function() { return iframe.contentDocument; },
   };
 }
@@ -59,28 +59,28 @@ describe('tabbable', function() {
   });
 
   [
-    { name: 'window', func: fixture },
-    { name: 'iframe\'s window', func: fixtureWithIframe },
+    { name: 'window', getFixture: fixture },
+    { name: 'iframe\'s window', getFixture: fixtureWithIframe },
   ].forEach(function (assertionSet) {
-
     describe(assertionSet.name, function() {
-    it('basic', function() {
-        var actual = fixture('basic').getTabbableIds();
-        var expected = [
-          'tabindex-hrefless-anchor',
-          'input',
-          'select',
-          'href-anchor',
-          'textarea',
-          'button',
-          'tabindex-div',
-          'hiddenParentVisible-button',
-        ];
-        assert.deepEqual(actual, expected);
+
+      it('basic', function() {
+          var actual = assertionSet.getFixture('basic').getTabbableIds();
+          var expected = [
+            'tabindex-hrefless-anchor',
+            'input',
+            'select',
+            'href-anchor',
+            'textarea',
+            'button',
+            'tabindex-div',
+            'hiddenParentVisible-button',
+          ];
+          assert.deepEqual(actual, expected);
       });
 
       it('nested', function() {
-        var actual = fixture('nested').getTabbableIds();
+        var actual = assertionSet.getFixture('nested').getTabbableIds();
         var expected = [
           'tabindex-div-2',
           'tabindex-div-0',
@@ -90,7 +90,7 @@ describe('tabbable', function() {
       });
 
       it('jqueryui', function() {
-        var actual = fixture('jqueryui').getTabbableIds();
+        var actual = assertionSet.getFixture('jqueryui').getTabbableIds();
         var expected = [
           // 1
           'formTabindex',
@@ -129,7 +129,7 @@ describe('tabbable', function() {
             return comparison || this.indexOf(b) - this.indexOf(a);
           })
         };
-        var actual = fixture('non-linear').getTabbableIds();
+        var actual = assertionSet.getFixture('non-linear').getTabbableIds();
         Array.prototype.sort = originalSort;
         var expected = [
           // 1
@@ -156,7 +156,7 @@ describe('tabbable', function() {
       });
 
       it('changing content', function() {
-        var loadedFixture = fixture('changing-content');
+        var loadedFixture = assertionSet.getFixture('changing-content');
         var actualA = loadedFixture.getTabbableIds();
         var expectedA = [
           'visible-button-1',
@@ -177,6 +177,7 @@ describe('tabbable', function() {
         ];
         assert.deepEqual(actualB, expectedB);
       });
+
     });
   });
 });


### PR DESCRIPTION
This enables `tabbable` to be invoked on elements of an iframe (as well as elements of the main window) and use the correct document context based on the subject element.