### PR TITLE
Add includeContainer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Summary of ordering principles:
 - First include any elements with positive `tabindex` attributes (1 or higher), ordered by ascending `tabindex` and source order.
 - Then include any elements with a zero `tabindex` and any element that by default receives focus (listed above) and does not have a positive `tabindex` set, in source order.
 
+### Options
+
+Second optional argument is options object. Currently there is only one option available:
+- `includeContainer`: if set to true, a tabbable containing node is included in returned array of nodes.
+
 ## Differences from jQuery UI's [`:tabbable` selector](https://api.jqueryui.com/tabbable-selector/)
 
 Doesn't need jQuery. Also: doesn't support all the old IE's.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-module.exports = function(el) {
+module.exports = function(el, options) {
+  options = options || {};
+
   var elementDocument = el.ownerDocument;
   var basicTabbables = [];
   var orderedTabbables = [];
@@ -17,6 +19,19 @@ module.exports = function(el) {
   ];
 
   var candidates = el.querySelectorAll(candidateSelectors);
+
+  if (options.includeContainer) {
+    var matches = Element.prototype.matches || Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+
+    if (
+      candidateSelectors.some(function(candidateSelector) {
+        return matches.call(el, candidateSelector);
+      })
+    ) {
+      candidates = Array.prototype.slice.apply(candidates);
+      candidates.unshift(el);
+    }
+  }
 
   var candidate, candidateIndex;
   for (var i = 0, l = candidates.length; i < l; i++) {

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -21,8 +21,8 @@ function createRootNode(doc, fixtureName) {
   return root;
 }
 
-function getTabbableIds(node) {
-  return tabbable(node).map(function(el) {
+function getTabbableIds(node, options) {
+  return tabbable(node, options).map(function(el) {
     return el.getAttribute('id');
   });
 }
@@ -176,6 +176,26 @@ describe('tabbable', function() {
           'initially-hidden-button-2',
         ];
         assert.deepEqual(actualB, expectedB);
+      });
+
+      it('including container', function() {
+        var loadedFixture = assertionSet.getFixture('nested');
+        var container = loadedFixture.getDocument().getElementById('tabindex-div-0')
+
+        var actualFalse = getTabbableIds(container);
+        var expectedFalse = [
+          'tabindex-div-2',
+          'input',
+        ];
+        assert.deepEqual(actualFalse, expectedFalse);
+
+        var actualTrue = getTabbableIds(container, {includeContainer: true});
+        var expectedTrue = [
+          'tabindex-div-2',
+          'tabindex-div-0',
+          'input',
+        ];
+        assert.deepEqual(actualTrue, expectedTrue);
       });
 
     });


### PR DESCRIPTION
Here is PR for #14.

Uses [matches](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches) and [some](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) both support IE9.