### PR TITLE
Fix crash when tabbable called with document

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function(el, options) {
   options = options || {};
 
-  var elementDocument = el.ownerDocument;
+  var elementDocument = el.ownerDocument || el;
   var basicTabbables = [];
   var orderedTabbables = [];
 

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -46,6 +46,15 @@ function fixtureWithIframe(fixtureName) {
   };
 }
 
+function fixtureWithDocument(fixtureName) {
+    var root = createRootNode(document, fixtureName);
+    fixtureRoots.push(root);
+    return {
+        getTabbableIds: getTabbableIds.bind(null, document),
+        getDocument: function() { return document; },
+    }
+}
+
 function cleanupFixtures() {
   fixtureRoots.forEach(function(root) {
     document.body.removeChild(root);
@@ -61,6 +70,7 @@ describe('tabbable', function() {
   [
     { name: 'window', getFixture: fixture },
     { name: 'iframe\'s window', getFixture: fixtureWithIframe },
+    { name: 'document', getFixture: fixtureWithDocument },
   ].forEach(function (assertionSet) {
     describe(assertionSet.name, function() {
 


### PR DESCRIPTION
#13 broke `tabbable(document)` since `ownerDocument` is `null` on all document nodes.[1] This PR fixes that calling pattern

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument