### PR TITLE
Use the documented `querySelectorAll` signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function(el, options) {
     '[tabindex]',
   ];
 
-  var candidates = el.querySelectorAll(candidateSelectors);
+  var candidates = el.querySelectorAll(candidateSelectors.join(','));
 
   if (options.includeContainer) {
     var matches = Element.prototype.matches || Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;


### PR DESCRIPTION
All major browsers accept array as `querySelectorAll` argument, but this isn't actually documented nor present in specifications

[MDN](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/querySelectorAll/#Syntax)
> `selectors` is a string containing one or more CSS selectors separated by commas.

[Selectors API spec](https://dev.w3.org/2006/webapi/selectors-api2/#interface-definitions)
[DOM spec](https://www.w3.org/TR/dom/#interface-parentnode)
>```
>NodeList  querySelectorAll(DOMString selectors);
>```

Currently it makes impossible to use tabbable and [dom4 polyfill](https://github.com/WebReflection/dom4) in one project, as it relies on `querySelectorAll` argument being a string