### PR TITLE
Fix `ReferenceError: Element is not defined` in Node.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ var candidateSelectors = [
 ];
 var candidateSelector = candidateSelectors.join(',');
 
-var matches = Element.prototype.matches || Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+var matches = typeof Element === 'undefined'
+  ? function () {}
+  : Element.prototype.matches || Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
 
 function tabbable(el, options) {
   options = options || {};


### PR DESCRIPTION
Since there's no `Element` global in Node.js, it's not safe to assume that `Element.prototype` exists. Looks like this broke in 3.0.0.

Tabbable isn't actually useful in server-side code, but universal React components may still end up loading Tabbable via focus-trap-react when rendering on the server.