### PR TITLE
Fix error when element is inside a Shadow DOM

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ function UntouchabilityChecker(elementDocument) {
 // getComputedStyle accurately reflects `visibility: hidden` of ancestors
 // but not `display: none`, so we need to recursively check parents.
 UntouchabilityChecker.prototype.hasDisplayNone = function hasDisplayNone(node, nodeComputedStyle) {
-  if (node === this.doc.documentElement) return false;
+  if (node.nodeType !== Node.ELEMENT_NODE) return false;
 
     // Search for a cached result.
     var cached = find(this.cache, function(item) {

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -270,6 +270,16 @@ describe('tabbable', function() {
         var n7 = assertionSet.getFixture('radio').getDocument().getElementById('radio-c');
         assert.ok(tabbable.isFocusable(n7));
       });
+
+      it('supports detached elements', function() {
+        var doc = assertionSet.getFixture('basic').getDocument();
+        var frag = doc.createDocumentFragment();
+        var button = doc.createElement('button');
+        frag.appendChild(button);
+
+        assert.isTrue(tabbable.isTabbable(button));
+        assert.isTrue(tabbable.isFocusable(button));
+      });
     });
   });
 });


### PR DESCRIPTION
In Web Components, the root element is a document fragment rather than an `<html>` element.

Fixes #34 and https://github.com/material-components/material-components-web/issues/4131