### PR TITLE
Optimize and simplify the function to test for visibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - '6'
+addons:
+  firefox: "65.0"
 cache: yarn
 before_script:
   - export DISPLAY=:99.0

--- a/index.js
+++ b/index.js
@@ -18,11 +18,9 @@ var matches = typeof Element === 'undefined'
 function tabbable(el, options) {
   options = options || {};
 
-  var elementDocument = el.ownerDocument || el;
   var regularTabbables = [];
   var orderedTabbables = [];
 
-  var untouchabilityChecker = new UntouchabilityChecker(elementDocument);
   var candidates = el.querySelectorAll(candidateSelector);
 
   if (options.includeContainer) {
@@ -36,7 +34,7 @@ function tabbable(el, options) {
   for (i = 0; i < candidates.length; i++) {
     candidate = candidates[i];
 
-    if (!isNodeMatchingSelectorTabbable(candidate, untouchabilityChecker)) continue;
+    if (!isNodeMatchingSelectorTabbable(candidate)) continue;
 
     candidateTabindex = getTabindex(candidate);
     if (candidateTabindex === 0) {
@@ -61,9 +59,9 @@ function tabbable(el, options) {
 tabbable.isTabbable = isTabbable;
 tabbable.isFocusable = isFocusable;
 
-function isNodeMatchingSelectorTabbable(node, untouchabilityChecker) {
+function isNodeMatchingSelectorTabbable(node) {
   if (
-    !isNodeMatchingSelectorFocusable(node, untouchabilityChecker)
+    !isNodeMatchingSelectorFocusable(node)
     || isNonTabbableRadio(node)
     || getTabindex(node) < 0
   ) {
@@ -72,18 +70,17 @@ function isNodeMatchingSelectorTabbable(node, untouchabilityChecker) {
   return true;
 }
 
-function isTabbable(node, untouchabilityChecker) {
+function isTabbable(node) {
   if (!node) throw new Error('No node provided');
   if (matches.call(node, candidateSelector) === false) return false;
-  return isNodeMatchingSelectorTabbable(node, untouchabilityChecker);
+  return isNodeMatchingSelectorTabbable(node);
 }
 
-function isNodeMatchingSelectorFocusable(node, untouchabilityChecker) {
-  untouchabilityChecker = untouchabilityChecker || new UntouchabilityChecker(node.ownerDocument || node);
+function isNodeMatchingSelectorFocusable(node) {
   if (
     node.disabled
     || isHiddenInput(node)
-    || untouchabilityChecker.isUntouchable(node)
+    || isHidden(node)
   ) {
     return false;
   }
@@ -91,10 +88,10 @@ function isNodeMatchingSelectorFocusable(node, untouchabilityChecker) {
 }
 
 var focusableCandidateSelector = candidateSelectors.concat('iframe').join(',');
-function isFocusable(node, untouchabilityChecker) {
+function isFocusable(node) {
   if (!node) throw new Error('No node provided');
   if (matches.call(node, focusableCandidateSelector) === false) return false;
-  return isNodeMatchingSelectorFocusable(node, untouchabilityChecker);
+  return isNodeMatchingSelectorFocusable(node);
 }
 
 function getTabindex(node) {
@@ -108,13 +105,6 @@ function getTabindex(node) {
 
 function sortOrderedTabbables(a, b) {
   return a.tabIndex === b.tabIndex ? a.documentOrder - b.documentOrder : a.tabIndex - b.tabIndex;
-}
-
-// Array.prototype.find not available in IE.
-function find(list, predicate) {
-  for (var i = 0, length = list.length; i < length; i++) {
-    if (predicate(list[i])) return list[i];
-  }
 }
 
 function isContentEditable(node) {
@@ -154,47 +144,8 @@ function isTabbableRadio(node) {
   return !checked || checked === node;
 }
 
-// An element is "untouchable" if *it or one of its ancestors* has
-// `visibility: hidden` or `display: none`.
-function UntouchabilityChecker(elementDocument) {
-  this.doc = elementDocument;
-  // Node cache must be refreshed on every check, in case
-  // the content of the element has changed. The cache contains tuples
-  // mapping nodes to their boolean result.
-  this.cache = [];
-}
-
-// getComputedStyle accurately reflects `visibility: hidden` of ancestors
-// but not `display: none`, so we need to recursively check parents.
-UntouchabilityChecker.prototype.hasDisplayNone = function hasDisplayNone(node, nodeComputedStyle) {
-  if (node.nodeType !== Node.ELEMENT_NODE) return false;
-
-    // Search for a cached result.
-    var cached = find(this.cache, function(item) {
-      return item === node;
-    });
-    if (cached) return cached[1];
-
-    nodeComputedStyle = nodeComputedStyle || this.doc.defaultView.getComputedStyle(node);
-
-    var result = false;
-
-    if (nodeComputedStyle.display === 'none') {
-      result = true;
-    } else if (node.parentNode) {
-      result = this.hasDisplayNone(node.parentNode);
-    }
-
-    this.cache.push([node, result]);
-
-    return result;
-}
-
-UntouchabilityChecker.prototype.isUntouchable = function isUntouchable(node) {
-  if (node === this.doc.documentElement) return false;
-  var computedStyle = this.doc.defaultView.getComputedStyle(node);
-  if (this.hasDisplayNone(node, computedStyle)) return true;
-  return computedStyle.visibility === 'hidden';
+function isHidden(node) {
+  return node.offsetParent === null || getComputedStyle(node).visibility === 'hidden';
 }
 
 module.exports = tabbable;

--- a/index.js
+++ b/index.js
@@ -145,6 +145,8 @@ function isTabbableRadio(node) {
 }
 
 function isHidden(node) {
+  // offsetParent being null will allow detecting cases where an element is invisible or inside an invisible element,
+  // as long as the element does not use position: fixed. For them, their visibility has to be checked directly as well.
   return node.offsetParent === null || getComputedStyle(node).visibility === 'hidden';
 }
 

--- a/test/fixtures/shadow-dom.html
+++ b/test/fixtures/shadow-dom.html
@@ -1,0 +1,7 @@
+<div id="shadow-host"></div>
+
+<template id="shadow-root-template">
+    <div id="container">
+        <input id="input" type="text">
+    </div>
+</template>

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -11,6 +11,7 @@ var fixtures = {
   'non-linear': fs.readFileSync(path.join(__dirname, 'fixtures/non-linear.html'), 'utf8'),
   'svg': fs.readFileSync(path.join(__dirname, 'fixtures/svg.html'), 'utf8'),
   'radio': fs.readFileSync(path.join(__dirname, 'fixtures/radio.html'), 'utf8'),
+  'shadow-dom': fs.readFileSync(path.join(__dirname, 'fixtures/shadow-dom.html'), 'utf8'),
 };
 
 var fixtureRoots = [];
@@ -271,15 +272,20 @@ describe('tabbable', function() {
         assert.ok(tabbable.isFocusable(n7));
       });
 
-      it('supports detached elements', function() {
-        var doc = assertionSet.getFixture('basic').getDocument();
-        var frag = doc.createDocumentFragment();
-        var button = doc.createElement('button');
-        frag.appendChild(button);
+      it('supports elements in a shadow root', function() {
+        var loadedFixture = assertionSet.getFixture('shadow-dom')
 
-        assert.isTrue(tabbable.isTabbable(button));
-        assert.isTrue(tabbable.isFocusable(button));
-      });
+        var host = loadedFixture.getDocument().getElementById('shadow-host')
+        var template = loadedFixture.getDocument().getElementById('shadow-root-template')
+        var shadow = host.attachShadow({mode: 'open'});
+        shadow.appendChild(template.content.cloneNode(true))
+
+        var actual = getTabbableIds(shadow.getElementById('container'))
+        var expected = [
+          'input',
+        ];
+        assert.deepEqual(actual, expected);
+      })
     });
   });
 });


### PR DESCRIPTION
This is taking over #32, fixing conflicts with newer changes.

This change is not only simplifying the code. It is also optimizing it a lot. When running focus-trap on an element containing a thousand checboxes (and a few other tabbable items), `updateTabbableNodes` (which is mostly a call to `tabbable`) went from 945ms to 15ms (on a rather powerful desktop browser).