### PR TITLE
Add details summary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ let candidateSelectors = [
   'audio[controls]',
   'video[controls]',
   '[contenteditable]:not([contenteditable="false"])',
+  'details>summary',
 ];
 let candidateSelector = candidateSelectors.join(',');
 

--- a/test/fixtures/details.html
+++ b/test/fixtures/details.html
@@ -1,0 +1,8 @@
+<details>
+  <summary id="details-a-summery">details A title</summary>
+  details A content
+</details>
+<details>
+  <summary id="details-b-summery">details B title</summary>
+  details B content
+</details>

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -15,6 +15,7 @@ module.exports = {
   ),
   svg: fs.readFileSync(path.join(__dirname, 'svg.html'), 'utf8'),
   radio: fs.readFileSync(path.join(__dirname, 'radio.html'), 'utf8'),
+  details: fs.readFileSync(path.join(__dirname, 'details.html'), 'utf8'),
   'shadow-dom': fs.readFileSync(
     path.join(__dirname, 'shadow-dom.html'),
     'utf8'

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -219,6 +219,12 @@ describe('tabbable', () => {
         assert.deepEqual(actual, expected);
       });
 
+      it('details', () => {
+        let actual = assertionSet.getFixture('details').getTabbableIds();
+        let expected = ['details-a-summery', 'details-b-summery'];
+        assert.deepEqual(actual, expected);
+      });
+
       it('tabbable.isTabbable', () => {
         let n1 = assertionSet
           .getFixture('basic')
@@ -255,6 +261,11 @@ describe('tabbable', () => {
           .getDocument()
           .getElementById('radio-c');
         assert.notOk(tabbable.isTabbable(n7));
+        let n8 = assertionSet
+          .getFixture('details')
+          .getDocument()
+          .getElementById('details-a-summery');
+        assert.ok(tabbable.isTabbable(n8));
       });
 
       it('tabbable.isFocusable', () => {
@@ -293,6 +304,11 @@ describe('tabbable', () => {
           .getDocument()
           .getElementById('radio-c');
         assert.ok(tabbable.isFocusable(n7));
+        let n8 = assertionSet
+          .getFixture('details')
+          .getDocument()
+          .getElementById('details-a-summery');
+        assert.ok(tabbable.isFocusable(n8));
       });
 
       it('supports elements in a shadow root', () => {


### PR DESCRIPTION
This PR adds any `<summary>` element directly under a `<details>` element as tabbable and focusable.